### PR TITLE
Removed polyfill

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,6 @@ extra_css:
   - assets/css/custom-auroris.css
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 markdown_extensions:


### PR DESCRIPTION
## Changelogs

- Removed the `polyfill` JS from our documentation

---

This is a hotfix needed due to a supply chain attack. See https://thehackernews.com/2024/06/over-110000-websites-affected-by.html
