### PR TITLE
No longer manually upgrade `mkdocs-jupyter` through PyPi in the CICD

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -28,7 +28,7 @@ jobs:
           pip install ruff
 
       - name: Lint
-        run: ruff .
+        run: ruff check .
 
       - name: Format
         run: ruff format . --check

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,11 +31,7 @@ jobs:
           cache-downloads: true
 
       - name: Install library
-        run: |
-          python -m pip install --no-deps .
-          # Note: Temporarily upgrade mkdocs-jupyter through PyPi
-          # See https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/30
-          python -m pip install mkdocs-jupyter -U --force-reinstall
+        run: python -m pip install --no-deps .
 
       - name: Configure git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,11 +100,7 @@ jobs:
           git push origin "${{ inputs.release-version }}"
 
       - name: Install library
-        run: |
-          python -m pip install --no-deps .
-          # Note: Temporarily upgrade mkdocs-jupyter through PyPi
-          # See https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/29
-          python -m pip install mkdocs-jupyter -U --force-reinstall
+        run: python -m pip install --no-deps .
 
       - name: Build the wheel and sdist
         run: python -m build --no-isolation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,7 @@ jobs:
             python=${{ matrix.python-version }}
 
       - name: Install library
-        run: |
-          python -m pip install --no-deps .
-          # Note: Temporarily upgrade mkdocs-jupyter through PyPi
-          # See https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/30
-          python -m pip install mkdocs-jupyter -U --force-reinstall
+        run: python -m pip install --no-deps .
 
 
       - name: Install UMAP

--- a/env.yml
+++ b/env.yml
@@ -41,7 +41,7 @@ dependencies:
   - mkdocs-material >=9.4.7
   - mkdocstrings
   - mkdocstrings-python
-  - mkdocs-jupyter
+  - mkdocs-jupyter >=0.24.8
   - markdown-include
   - mdx_truly_sane_lists
   - nbconvert


### PR DESCRIPTION
## Changelogs

- No longer manually upgrade `mkdocs-jupyter` through PyPi in the CICD

---

For details, see https://github.com/conda-forge/mkdocs-jupyter-feedstock/issues/31
