### PR TITLE
Add rdkit and matplotlib as explicit dependencies 

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -18,8 +18,10 @@ dependencies:
   - scipy
   - scikit-learn
   - seaborn
+  - matplotlib
 
   # Chemistry
+  - rdkit
   - datamol >=0.12.1
 
   # Visualization


### PR DESCRIPTION
## Changelogs

- Add `rdkit` and `matplotlib` as explicit dependencies 

